### PR TITLE
Pass down casperArgs and reports to PhantomFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,28 @@ grunt.config.set('phantomflow', {
 			Default value is 4
 		*/
 		threads: 4
-		
+
+		/*
+			Any command line options to be passed down to casper?
+			Example: ['--cookies-file=testcookies.txt']
+			Default value is []
+		*/
+		casperArgs: [],
+
 		/*
 			Should a report/visualisation be generated after
 			the test run? Default value is false
 		*/
 		createReport: false,
+
+		/*
+			Should the report output live somewhere else, e.g. for
+			proxying through a real webserver?
+			Example: '../visualtest/htdocs'
+			Default value is undefined.
+			If unset, the default set by PhantomFlow will be used.
+		*/
+		reports: null,
 		
 		/*
 			Do you have scripts to include?

--- a/tasks/phantomflow.js
+++ b/tasks/phantomflow.js
@@ -11,7 +11,9 @@ module.exports = function ( grunt ) {
 		var phantomflow = require( 'phantomflow' ).init( {
 			test: grunt.option( 'test' ), // to run a specific test
 			debug: grunt.option( 'debug' ),
+			casperArgs: this.data.casperArgs || [],
 			createReport: this.data.createReport,
+			reports: this.data.reports,
 			includes: this.data.includes,
 			tests: this.data.tests,
 			results: this.data.results,


### PR DESCRIPTION
It is really helpful to pass down casperArgs to PhantomFlow, e.g. to enable using cookies in the test cases.
To expose the reports to the world it is good to be able to specify the output target (this needs a tweaked PhantomFlow, a PR for that will follow soon).