### PR TITLE
Adds comma to example config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ grunt.config.set('phantomflow', {
 			How many threads would you like to parallelise on?
 			Default value is 4
 		*/
-		threads: 4
+		threads: 4,
 
 		/*
 			Any command line options to be passed down to casper?


### PR DESCRIPTION
Not a huge deal, just thought it might help save someone the three seconds of confusion I experienced earlier today.