### PR TITLE
Add PhantomFlow option "dashboard"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "grunt-phantomflow",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "UI Web testing with decision trees and PhantomCSS",
 	"homepage": "https://github.com/Huddle/grunt-phantomflow",
 	"author": "",

--- a/tasks/phantomflow.js
+++ b/tasks/phantomflow.js
@@ -17,6 +17,7 @@ module.exports = function ( grunt ) {
 			mismatchTolerance: grunt.option('mismatchTolerance'),
 			earlyExit: grunt.option( 'earlyexit' ),
 			novisuals: grunt.option( 'novisuals' ),
+			dashboard: grunt.option('dashboard'),
 		};
 
 		var phantomflow = require( 'phantomflow' ).init( _.defaults( overrides, this.data ) );


### PR DESCRIPTION
Added new pass-through option to enable/disable the PhantomFlow console dashboard.  This is critical for CI build systems that don't work with the dashboard enabled.